### PR TITLE
watcher: fix boolean return value

### DIFF
--- a/vcd/watcher.py
+++ b/vcd/watcher.py
@@ -134,4 +134,4 @@ class VCDWatcher:
     # (for instance, only on rising clock edges)
     def should_notify(self):
         # Called every time something in the sensitivity list changes
-        return true
+        return True


### PR DESCRIPTION
The boolean return value is updated from `true` to `True` in order to fix the following error:
`NameError: name 'true' is not defined`